### PR TITLE
Make pdfviewer support full paths

### DIFF
--- a/bin/pdfviewer
+++ b/bin/pdfviewer
@@ -3,7 +3,9 @@
 # to the pdfviewer llpp via inotify.
 
 # Prepare parameters.
-pdf="$1"
+oldpath=$PWD
+cd `dirname $1`
+pdf=`basename $1`
 shift
 passthrou="$@"
 
@@ -37,3 +39,4 @@ pid_inotify=$(jobs -p | grep -v $pid_llpp)
 # If llpp terminates kill the inotifywait process.
 wait $pid_llpp
 kill $pid_inotify
+cd $oldpath


### PR DESCRIPTION
Currently only `pdfviewer hello.pdf` works, but `pdfviewer /path/to/hello.pdf` doesn’t. This patch fixes this by changing the working directory to the one containing the PDF file, and after `llpp` is closed it returns to the original directory.

Thanks a lot for `pdfviewer` :-). I use it for writing my PhD thesis in LaTeX.