### PR TITLE
A more elegant solution for #2 and quiet output

### DIFF
--- a/bin/pdfviewer
+++ b/bin/pdfviewer
@@ -25,7 +25,7 @@ trap "kill ${pid_llpp}" SIGINT SIGTERM SIGQUIT SIGKILL
 
 # Watch for changes in the directory of the given file. This is necessary
 # to recieve events after the file was deleted.
-inotifywait -m -e close_write "$PWD" | while read dir ev file; do
+inotifywait -m -e close_write "$PWD" -q | while read dir ev file; do
     # Only refresh on events of the file in question and if this file exists.
     if [ "$file" = "$pdf" ] && [ -e "$pdf" ]; then
         kill -HUP $pid_llpp

--- a/bin/pdfviewer
+++ b/bin/pdfviewer
@@ -3,8 +3,7 @@
 # to the pdfviewer llpp via inotify.
 
 # Prepare parameters.
-oldpath=$PWD
-cd `dirname $1`
+pushd `dirname $1` >/dev/null
 pdf=`basename $1`
 shift
 passthrou="$@"
@@ -39,4 +38,4 @@ pid_inotify=$(jobs -p | grep -v $pid_llpp)
 # If llpp terminates kill the inotifywait process.
 wait $pid_llpp
 kill $pid_inotify
-cd $oldpath
+popd >/dev/null


### PR DESCRIPTION
After I’ve already sent pull request #2, I realized this should use `pushd` and `popd`, not some ugly variable hack. This is fixed by  36938e6.

In addition, `inotifywait`’s output is unnecessary, so I added `-q`. fde3c8d.